### PR TITLE
Change URL to official Tabler Icons website

### DIFF
--- a/index.md
+++ b/index.md
@@ -11468,7 +11468,7 @@
       rel="nofollow">IconFinder</a>, <a href="https://www.flaticon.com/" rel="nofollow">Flaticon</a>, <a
       href="https://www.svgrepo.com/" rel="nofollow">SVG Repo</a>, <a href="https://simpleicons.org/"
       rel="nofollow">SimpleIcons</a>, <a href="https://thenounproject.com/" rel="nofollow">Noun Project</a>, <a
-      href="https://tablericons.com/" rel="nofollow">tablericons</a>, <a
+      href="https://tabler.io/icons/" rel="nofollow">Tabler Icons</a>, <a
       href="https://www.google.com/search?q=site%3Agumroad.com+%240+icons" rel="nofollow">Gumroad</a>, <a
       href="https://www.iconpacks.net/" rel="nofollow">IconPacks</a>, <a href="https://streamlineicons.com/download/"
       rel="nofollow">Streamline Icons</a>, <a href="https://game-icons.net/" rel="nofollow">game-icons</a>, <a


### PR DESCRIPTION
Hi @lkrjangid1, I hope you’re doing well!

I wanted to kindly ask if you could update the link to Tabler Icons to the correct URL: https://tabler.io/icons.

The current site, tablericons. com, isn’t affiliated with the Tabler Icons project. The person behind it is misleading users by claiming to be the author of the library. You can verify the official project and its details here: https://github.com/tabler/tabler-icons.

Thanks so much for your understanding and for supporting accurate representation of the Tabler project!

Best regards
Bartek, co-owner of https://github.com/tabler
